### PR TITLE
added heuristic detection methods to survey-template

### DIFF
--- a/questionnaires/jspsych-survey-template.js
+++ b/questionnaires/jspsych-survey-template.js
@@ -306,7 +306,7 @@ jsPsych.plugins['survey-template'] = (function() {
 
     // Add event listener.
     function log_event(event) {
-      const response_time = Math.round(performance.now() - startTime);
+      const response_time = performance.now() - startTime;
       if (event.screenX > 0) {
         mouse_events.push( response_time );
       } else {


### PR DESCRIPTION
To address #9: Added heuristic responding detection to jspsych-survey-template. Specifically, the plugin now returns a score (bounded in [0-1]) that indicates the percentage of responses consistent with straight-lining (i.e. responding using only one radio button position) and zig-zagging (i.e. responding using adjacent buttons for successive items).  